### PR TITLE
Update gitee links to github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ to implement the image classification.
 ## Docs
 
 More details about installation guide, tutorials and APIs, please see the
-[User Documentation](https://gitee.com/mindspore/docs).
+[User Documentation](https://github.com/mindspore-ai/docs).
 
 ## Community
 
 ### Governance
 
-Check out how MindSpore Open Governance [works](https://gitee.com/mindspore/community/blob/master/governance.md).
+Check out how MindSpore Open Governance [works](https://github.com/mindspore-ai/community/blob/master/governance.md).
 
 ### Communication
 


### PR DESCRIPTION
Since your docs are updated simultaneously on both github and gitee, I think it might be better if the github project points to the github docs.