### PR TITLE
fix(docker): fix env path in dockerfile

### DIFF
--- a/docker/mindspore-cpu/1.0.0/Dockerfile
+++ b/docker/mindspore-cpu/1.0.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER leonwanghui <leon.wanghui@huawei.com>
 
 # Set env
 ENV PYTHON_ROOT_PATH /usr/local/python-3.7.5
-ENV PATH /usr/local/bin:$PATH
+ENV PATH /usr/local/bin:/root/.local/bin:$PATH
 
 # Install base tools
 RUN apt update \


### PR DESCRIPTION
**What type of PR is this?**

`/kind bug`

**What does this PR do / why do we need it**:

In the `1.0.0` Docker image, pip is configured in a way that all command line entrypoints are installed into `/root/.local/bin`. However, `/root/.local/bin` is not in the `PATH` env variables. This causes the problem that **all** Python packages that have CLI interfaces will throw "Command not found" error.

For example,

```dockerfile
FROM mindspore/mindspore-cpu:1.0.0

RUN pip install --user pytest && pytest 
```

In this particular case, one workaround is to use `python -m pytest`. However, not all CLI-enabled packages implement this usage.

**Which issue(s) this PR fixes**:

This PR adds `/root/.local/bin` to env `PATH` inside Mindspore Dockerfile, so that all images built on top of `mindspore` will not suffer from this usability issue.

**Special notes for your reviewers**:

Please note that this should be applied to all Dockerfiles. Right now I'm just fixing one to showcase the problem and confirm with your dev team to see if this is the way to go.

