### PR TITLE
[BugFix][OpenCL] Fix GenerateLocalByGlobal with CL_INVALID_WORK_GROUP_SIZE

### DIFF
--- a/mindspore/lite/src/runtime/kernel/opencl/opencl_kernel.cc
+++ b/mindspore/lite/src/runtime/kernel/opencl/opencl_kernel.cc
@@ -338,7 +338,9 @@ std::set<size_t> OpenCLKernel::GenerateLocalByGlobal(size_t global_i) {
   std::set<size_t> local_ = {};
   int index = 1;
   while (index <= global_i) {
-    local_.insert(index);
+    if (global_i % index == 0) {
+      local_.insert(index);
+    }
     index *= 2;
   }
   for (size_t i = 1; i <= 16; i++) {


### PR DESCRIPTION
> CL_INVALID_WORK_GROUP_SIZE if local_work_size is specified and number of work-items specified by global_work_size is not evenly divisable by size of work-group given by local_work_size or does not match the work-group size specified for kernel using the __attribute__((reqd_work_group_size(X, Y, Z))) qualifier in program source.