### PR TITLE
Add support for StringType const node conversion in PyTorch model converter

### DIFF
--- a/mindspore/lite/tools/converter/parser/pytorch/pytorch_model_parser.cc
+++ b/mindspore/lite/tools/converter/parser/pytorch/pytorch_model_parser.cc
@@ -316,6 +316,10 @@ STATUS PytorchModelParser::ConvertConstNode(const torch::jit::Node *torch_node, 
       auto data = static_cast<float>(value.value().toDouble());
       parameter = opt::BuildFloatValueParameterNode(anf_graph, data, output->debugName());
     } break;
+    case c10::TypeKind::StringType: {
+      auto data = static_cast<std::string>(value.value().toStringRef());
+      parameter = opt::BuildStringValueParameterNode(anf_graph, data, output->debugName());
+    } break;
     case c10::TypeKind::ListType: {
       auto element_type = value->toList().elementType()->kind();
       switch (element_type) {

--- a/mindspore/lite/tools/optimizer/common/gllo_utils.cc
+++ b/mindspore/lite/tools/optimizer/common/gllo_utils.cc
@@ -944,6 +944,27 @@ ParameterPtr BuildIntVec2DParameterNode(const FuncGraphPtr &func_graph, const st
   return param_node;
 }
 
+ParameterPtr BuildStringValueParameterNode(const FuncGraphPtr &func_graph, const std::string &data,
+                                          const std::string &node_name, bool empty_shape) {
+  MS_CHECK_TRUE_RET(func_graph != nullptr, nullptr);
+  auto param_node = func_graph->add_parameter();
+  MS_CHECK_TRUE_RET(param_node != nullptr, nullptr);
+  param_node->set_name(node_name);
+
+  std::vector<int64_t> shape_vector{static_cast<int64_t>(data.size())};
+  auto tensor_info = lite::CreateTensorInfo(data.c_str(), data.size(), shape_vector, kObjectTypeString);
+  if (tensor_info == nullptr) {
+    MS_LOG(ERROR) << "Create tensor info failed";
+    return nullptr;
+  }
+  auto status = lite::InitParameterFromTensorInfo(param_node, tensor_info);
+  if (status != RET_OK) {
+    MS_LOG(ERROR) << "init parameter from tensor info failed";
+    return nullptr;
+  }
+  return param_node;
+}
+
 ParameterPtr BuildFloatValueParameterNode(const FuncGraphPtr &func_graph, const float &data,
                                           const std::string &node_name, bool empty_shape) {
   MS_CHECK_TRUE_RET(func_graph != nullptr, nullptr);

--- a/mindspore/lite/tools/optimizer/common/gllo_utils.h
+++ b/mindspore/lite/tools/optimizer/common/gllo_utils.h
@@ -119,6 +119,9 @@ ParameterPtr BuildIntVecParameterNode(const FuncGraphPtr &func_graph, const std:
 ParameterPtr BuildIntVec2DParameterNode(const FuncGraphPtr &func_graph, const std::vector<std::vector<int32_t>> &data,
                                         const std::string &node_name);
 
+ParameterPtr BuildStringValueParameterNode(const FuncGraphPtr &func_graph, const std::string &data,
+                                          const std::string &node_name, bool empty_shape = false);
+
 ParameterPtr BuildFloatValueParameterNode(const FuncGraphPtr &func_graph, const float &data,
                                           const std::string &node_name, bool empty_shape = false);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://github.com/mindspore-ai/mindspore/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `mindspore-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
`/kind feature`

**What does this PR do / why do we need it**:
Support converting StringType const node in the exported PyTorch model

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewers**:

