### PR TITLE
Added preconditions to avoid write-write data-race

### DIFF
--- a/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
+++ b/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
@@ -24,6 +24,9 @@ using Complex = mindspore::utils::Complex<T>;
 
 template <typename T>
 __global__ void MatrixTransposeKernel(const T *input, int elements, int row, int col, T *output) {
+  if (col <= 0 || row <= 0 || row != col) {
+    return;
+  }
   const int matrix_size = row * col;
   for (int pos = blockIdx.x * blockDim.x + threadIdx.x; pos < elements; pos += blockDim.x * gridDim.x) {
     const int b = pos / matrix_size;

--- a/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
+++ b/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
@@ -24,7 +24,7 @@ using Complex = mindspore::utils::Complex<T>;
 
 template <typename T>
 __global__ void MatrixTransposeKernel(const T *input, int elements, int row, int col, T *output) {
-  if (col <= 0 || row <= 0 || row != col) {
+  if (col < 0 || row < 0 ) {
     return;
   }
   const int matrix_size = row * col;

--- a/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
+++ b/mindspore/ccsrc/plugin/device/gpu/kernel/cuda_impl/cuda_ops/matrix_transpose_impl.cu
@@ -24,7 +24,16 @@ using Complex = mindspore::utils::Complex<T>;
 
 template <typename T>
 __global__ void MatrixTransposeKernel(const T *input, int elements, int row, int col, T *output) {
+template <typename T>
+cudaError_t MatrixTranspose(const T *input, int elements, int row, int col, T *output, uint32_t device_id,
+                            cudaStream_t cuda_stream) {
   if (col < 0 || row < 0 ) {
+    return cudaErrorInvalidValue;
+  }
+  MatrixTransposeKernel<<<CUDA_BLOCKS(device_id, elements), CUDA_THREADS(device_id), 0, cuda_stream>>>(
+    input, elements, row, col, output);
+  return GetCudaStatus();
+}
     return;
   }
   const int matrix_size = row * col;


### PR DESCRIPTION
`/kind bug`</br>

#### Summary:
 In [issue](https://github.com/mindspore-ai/mindspore/issues/262), our tool found a write-write data-race on array output, given certain values of col,row, and elements.
We added preconditions (which may not be the minimal preconditions) to prevent the race.



 `mindspore-assistant` 